### PR TITLE
fix: resolve double confirmation dialog bug in clear all marks

### DIFF
--- a/lua/marksman/ui.lua
+++ b/lua/marksman/ui.lua
@@ -329,9 +329,10 @@ local function setup_window_keymaps(buf, marks, project_name, mark_info, search_
 			prompt = "Clear all marks in this project?",
 		}, function(choice)
 			if choice == "Yes" then
-				local marksman = require("marksman")
-				marksman.clear_all_marks()
+				local storage = require("marksman.storage")
+				storage.clear_all_marks()
 				close_window()
+				notify("󰃀 All marks cleared", vim.log.levels.INFO)
 			end
 		end)
 	end


### PR DESCRIPTION
Call storage.clear_all_marks() directly instead of marksman.clear_all_marks()