### PR TITLE
Implemented goto_next & goto_previous

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Vim's built-in marks are great, but they're global and get messy fast. Marksman 
 - **Persistent storage** - Your marks survive Neovim restarts with automatic backup
 - **Smart naming** - Context-aware auto-generation using Treesitter and pattern matching
 - **Quick access** - Jump to marks with single keys or interactive UI
-- **Sequential navigation** — Jump to the closest mark relative to your cursor, fallback to jump from mark 1 when no marks are in the current file
+- **Sequential navigation** — Jumps relative to the nearest mark in the current file. If the current file has no marks, next jumps to the first mark and previous jumps to the last.
 - **Enhanced search** - Find marks by name, file path, or content with real-time filtering
 - **Mark reordering** - Move marks up/down to organize them as needed
 - **Multiple integrations** - Works with Telescope, Snacks.nvim, and more

--- a/lua/marksman/init.lua
+++ b/lua/marksman/init.lua
@@ -289,16 +289,15 @@ function M.goto_mark(name_or_index)
 	end
 end
 
--- Finds the mark index closest to the current cursor position, using 1 as fallback.
+-- Finds the mark index closest to the current cursor position.
 -- Returns:
---   index (number | nil): the resolved mark index, or nil if no marks exist
---   total (number | nil): total number of marks when successful, nil on failure
---   error (string | nil): error message when no marks are available
+--   current_index (number | nil): exact or closest index in current file, or nil if none in file
+--   total_marks (number | nil): total number of marks, nil if no marks exist
+--   error (string | nil): error message only when no marks exist at all
 local function get_current_mark_index(storage_module)
 	local mark_names = storage_module.get_mark_names()
-	local count = #mark_names
-
-	if count == 0 then
+	local total_marks = #mark_names
+	if total_marks == 0 then
 		return nil, nil, "No marks available"
 	end
 
@@ -306,31 +305,31 @@ local function get_current_mark_index(storage_module)
 	local current_file = vim.fn.expand("%:p")
 	local current_line = vim.fn.line(".")
 
-	local best_index = nil
-	local best_distance = nil
+	local nearest_index = nil
+	local shortest_distance = nil
 
 	for index, mark_name in ipairs(mark_names) do
 		local mark = marks[mark_name]
 		if mark.file == current_file then
 			if mark.line == current_line then
-				return index, count, nil
+				return index, total_marks, nil
 			end
 			local distance = math.abs(mark.line - current_line)
-			if not best_distance or distance < best_distance then
-				best_index = index
-				best_distance = distance
+			if not shortest_distance or distance < shortest_distance then
+				nearest_index = index
+				shortest_distance = distance
 			end
 		end
 	end
 
-	return best_index or 1, count, nil
+	return nearest_index, total_marks, nil
 end
 
 ---Jump to the next mark.
 ---Navigation is context-aware:
 ---• If the cursor is on a mark, jump relative to it.
 ---• If the cursor is not on a mark, select the nearest mark in the same file before jumping.
----• If the current file has no marks, fall back to first index before jumping.
+---• If the current file has no marks, jump to the first index.
 ---Wraps when reaching the last mark.
 ---@return table result Result with success and optional message
 function M.goto_next()
@@ -340,11 +339,15 @@ function M.goto_next()
 	end
 
 	local current_index, count, err = get_current_mark_index(storage_module)
-	if not current_index then
+	if err then
 		return { success = false, message = err }
 	end
-
-	local next_index = (current_index % count) + 1
+	local next_index
+	if not current_index then
+		next_index = 1
+	else
+		next_index = (current_index % count) + 1
+	end
 	return M.goto_mark(next_index)
 end
 
@@ -352,7 +355,7 @@ end
 ---Navigation is context-aware:
 ---• If the cursor is on a mark, jump relative to it.
 ---• If the cursor is not on a mark, select the nearest mark in the same file before jumping.
----• If the current file has no marks, fall back to first index before jumping.
+---• If the current file has no marks, jump to the last index.
 ---Wraps when reaching the last mark.
 ---@return table result Result with success and optional message
 function M.goto_previous()
@@ -362,11 +365,16 @@ function M.goto_previous()
 	end
 
 	local current_index, count, err = get_current_mark_index(storage_module)
-	if not current_index then
+	if err then
 		return { success = false, message = err }
 	end
 
-	local previous_index = ((current_index - 2) % count) + 1
+	local previous_index
+	if not current_index and count then
+		previous_index = count
+	else
+		previous_index = ((current_index - 2) % count) + 1
+	end
 	return M.goto_mark(previous_index)
 end
 

--- a/tests/marksman_spec.lua
+++ b/tests/marksman_spec.lua
@@ -207,7 +207,7 @@ describe("marksman.nvim", function()
 			assert.equals(1, vim.fn.line("."), "Should move to b1")
 		end)
 
-		it("jumps to second mark when current file has no marks", function()
+		it("jumps to first mark when current file has no marks", function()
 			-- file A with marks
 			vim.cmd("edit " .. test_file)
 			vim.fn.cursor(1, 1)
@@ -221,10 +221,8 @@ describe("marksman.nvim", function()
 
 			local result = marksman.goto_next()
 			assert.is_true(result.success)
-
-			-- Should jump to second mark because fallback picks first index
 			assert.equals(test_file, vim.fn.expand("%:p"))
-			assert.equals(2, vim.fn.line("."), "Should move to m2")
+			assert.equals(1, vim.fn.line("."), "Should move to m1")
 		end)
 
 		it("jumps to first mark when only 1 mark exists", function()
@@ -277,6 +275,24 @@ describe("marksman.nvim", function()
 			result = marksman.goto_previous()
 			assert.is_true(result.success)
 			assert.equals(1, vim.fn.line("."), "Should jump from m2 to m1")
+		end)
+
+		it("jumps to last mark when current file has no marks", function()
+			-- file A with marks
+			vim.cmd("edit " .. test_file)
+			vim.fn.cursor(1, 1)
+			marksman.add_mark("m1")
+			vim.fn.cursor(2, 1)
+			marksman.add_mark("m2")
+
+			-- file B with zero marks
+			vim.cmd("edit " .. test_file2)
+			vim.fn.cursor(1, 1)
+
+			local result = marksman.goto_previous()
+			assert.is_true(result.success)
+			assert.equals(test_file, vim.fn.expand("%:p"))
+			assert.equals(2, vim.fn.line("."), "Should move to m2")
 		end)
 
 		it("deletes marks", function()


### PR DESCRIPTION
## Description
This PR implements `goto_next()` and `goto_previous()` navigation functions as requested in [#20](https://github.com/alexekdahl/marksman.nvim/issues/20). These functions allow programmatic navigation between marks without relying on the UI picker or static keybindings. They use the closest mark within the current file as the current reference position and apply wrap-around navigation when reaching the start/end of the list. This enables plugin authors and advanced users to build custom navigation workflows and integrate marksman’s mark navigation into other tools.

## Type of Change
- [x] New feature (non-breaking change which adds functionality)

## Testing
- [x] Tests pass locally (`just test`)
- [x] Added new tests for this change
- [x] Tested manually in multiple scenarios

Describe specific testing done:
- Added `goto_next` and `goto_previous` tests including wrap-around
- Verified navigation works when cursor is on a mark, near a mark, and in files with multiple marks
- Verified correct fallback behavior when no marks are in the current file
- Confirmed sensible error behavior when fewer than two marks exist

## Breaking Changes
None. This is a new API surface and does not affect existing commands or keymaps.

## Checklist
- [x] Code follows style guidelines (`just lint` passes)
- [x] Code is formatted (`just format` applied)
- [x] Self-review completed
- [x] Documentation updated (added brief usage notes where appropriate)
- [x] No console logs or debug code left behind

## Additional Notes
Resolves #20 