### PR TITLE
fix(ui): correct mark name highlight offset by one

### DIFF
--- a/lua/marksman/ui.lua
+++ b/lua/marksman/ui.lua
@@ -172,7 +172,7 @@ local function create_minimal_mark_line(name, mark, index, line_idx)
 	})
 
 	-- Name highlight
-	local name_start = 5 + #tostring(index)
+	local name_start = 4 + #tostring(index)
 	local name_end = name_start + math.min(20, #name)
 	table.insert(highlights, {
 		line = line_idx,


### PR DESCRIPTION
Adjusted name_start calculation so the first character of mark names is highlighted properly and added tests to cover single and multi-digit indices.

Solves: #23
