### PR TITLE
feat(ui): add configurable window position

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,9 @@ Vim's built-in marks are great, but they're global and get messy fast. Marksman 
     silent = false,
     disable_default_keymaps = false,
     debounce_ms = 500,
+    ui = {
+      position = "center",  -- "center", "top_center", or "bottom_center"
+    },
   },
 }
 ```
@@ -129,6 +132,9 @@ require("marksman").setup({
   silent = false,            -- Suppress notifications
   disable_default_keymaps = false,
   debounce_ms = 500,         -- Save debounce (100-5000ms)
+  ui = {
+    position = "center",     -- Window position: "center", "top_center", or "bottom_center"
+  },
   highlights = {
     ProjectMarksTitle = { fg = "#61AFEF", bold = true },
     ProjectMarksNumber = { fg = "#C678DD" },

--- a/lua/marksman/init.lua
+++ b/lua/marksman/init.lua
@@ -34,19 +34,15 @@ local default_config = {
 	},
 	auto_save = true,
 	max_marks = 100,
-	search_in_ui = true,
 	silent = false,
-	-- minimal should be configured via ui opts
 	minimal = false,
 	disable_default_keymaps = false,
 	debounce_ms = 500, -- Debounce save operations
-	-- UI specific settings
 	ui = {
 		-- Position of the marks window.
 		-- "center" positions the window in the middle of the editor (default).
 		-- "top_center" aligns the window at the top of the screen, centered horizontally.
 		-- "bottom_center" aligns the window at the bottom of the screen, centered horizontally.
-		minimal = false,
 		position = "center",
 	},
 }
@@ -55,11 +51,19 @@ local default_config = {
 local config_schema = {
 	auto_save = { type = "boolean" },
 	max_marks = { type = "number", min = 1, max = 1000 },
-	search_in_ui = { type = "boolean" },
 	silent = { type = "boolean" },
 	minimal = { type = "boolean" },
 	disable_default_keymaps = { type = "boolean" },
 	debounce_ms = { type = "number", min = 100, max = 5000 },
+	ui = {
+		type = "table",
+		fields = {
+			position = {
+				type = "string",
+				allowed = { "center", "top_center", "bottom_center" },
+			},
+		},
+	},
 }
 
 local config = {}
@@ -742,4 +746,3 @@ function M.setup(opts)
 end
 
 return M
-

--- a/lua/marksman/init.lua
+++ b/lua/marksman/init.lua
@@ -36,9 +36,19 @@ local default_config = {
 	max_marks = 100,
 	search_in_ui = true,
 	silent = false,
+	-- minimal should be configured via ui opts
 	minimal = false,
 	disable_default_keymaps = false,
 	debounce_ms = 500, -- Debounce save operations
+	-- UI specific settings
+	ui = {
+		-- Position of the marks window.
+		-- "center" positions the window in the middle of the editor (default).
+		-- "top_center" aligns the window at the top of the screen, centered horizontally.
+		-- "bottom_center" aligns the window at the bottom of the screen, centered horizontally.
+		minimal = false,
+		position = "center",
+	},
 }
 
 -- Configuration validation schema
@@ -732,3 +742,4 @@ function M.setup(opts)
 end
 
 return M
+


### PR DESCRIPTION
Users can now choose where the floating marks window appears on the screen via the new ui.position option.

This change improves UI flexibility, especially for users who prefer to keep the main editing area visible below the marks window. It makes the plugin’s interface more customizable without complicating setup.

```
require("marksman").setup({
  ui = {
    position = "top_center", -- options: "center" (default), "top_center", "bottom_center"
  },
})
```
center (default): Keeps the existing centered window behavior.
top_center: Aligns the window near the top of the screen.
bottom_center: Aligns the window near the bottom.

If an invalid value is provided, the window gracefully falls back to center.


Addressing [#24](https://github.com/alexekdahl/marksman.nvim/issues/24)
<img width="1764" height="1135" alt="Screenshot from 2025-11-08 21-36-34" src="https://github.com/user-attachments/assets/0c7d2be9-affc-4a31-985d-0b716323eec2" />
<img width="1764" height="1135" alt="Screenshot from 2025-11-08 21-35-40" src="https://github.com/user-attachments/assets/a26e1f20-0846-4d45-aefa-db216c535054" />

